### PR TITLE
Learn multiple recipes with one toast

### DIFF
--- a/src/main/resources/assets/rockbottom/loc/us_english.json
+++ b/src/main/resources/assets/rockbottom/loc/us_english.json
@@ -109,6 +109,9 @@
             "disconnect": "&6Player %s disconnected!",
             "last_modified": "Last Played",
             "seed": "Seed",
+            "recipe_learned": "Recipe Learned",
+            "recipes_learned": "Recipes Learned",
+            "recipe_forgotten": "Recipe Forgotten",
             "durability.": {
                 "high": "&aPristine",
                 "medium_high": "&aSlightly Used",


### PR DESCRIPTION
When you unlock multiple recipes at once, you no longer get spammed with toasts and instead get a single toast which cycles through recipes.